### PR TITLE
ci: rename workflow job to match required status check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ bin/*
 
 # Config file should not leak
 ./config.yaml
+
+# Scratch files in tmp/
+tmp/


### PR DESCRIPTION
## Summary
- Renames the GitHub Actions workflow job from `build` to `test` to match the required status check name in the repo rules
- This was preventing all pushes to master with: `Required status check "test" is expected`

## Test plan
- [ ] CI "test" job runs and passes on this PR
- [ ] PR can be merged to master after check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)